### PR TITLE
Add payment_button_label shortcode attribute

### DIFF
--- a/stripe-checkout/includes/shortcodes.php
+++ b/stripe-checkout/includes/shortcodes.php
@@ -29,6 +29,7 @@ function sc_stripe_shortcode( $attr ) {
 					'checkout_button_label' => '',
 					'billing'               => '',
 					'shipping'              => '',
+					'payment_button_label'  => '',
 					'enable_remember'       => ''
 				), $attr ) );
 	
@@ -61,6 +62,7 @@ function sc_stripe_shortcode( $attr ) {
 	$script_options .= ( ! empty( $checkout_button_label ) ? 'data-panel-label="' . esc_attr( $checkout_button_label ) . '" ' : '' );
 	$script_options .= ( ! empty( $billing ) ? 'data-billing-address="' . esc_attr( $billing ) . '" ' : '' );
 	$script_options .= ( ! empty( $shipping ) ? 'data-shipping-address="' . esc_attr( $shipping ) . '" ' : '' );
+	$script_options .= ( ! empty( $payment_button_label ) ? 'data-label="' . esc_attr( $payment_button_label ) . '" ' : '' );
 	$script_options .= ( ! empty( $enable_remember ) ? 'data-allow-remember-me="' . esc_attr( $enable_remember ) . '" ' : '' );
 	
 	


### PR DESCRIPTION
Allows user to change the text of the default blue payment button
