### PR TITLE
Exclude Legacy Code on New Installs

### DIFF
--- a/includes/old/stripe-checkout.php
+++ b/includes/old/stripe-checkout.php
@@ -92,10 +92,13 @@ register_activation_hook( SC_PLUGIN_FILE, array( 'Stripe_Checkout', 'activate' )
 global $base_class;
 
 /**
- * Show a deprecation notice about 1.x shortcode/settings.
+ * Determine if legacy settings need to be exposed.
+ *
+ * @since 2.1.0
+ *
+ * @return bool
  */
-function simpay_lite_deprecation_notice() {
-
+function simpay_lite_needs_legacy() {
 	$settings_1 = get_option( 'sc_settings' );
 	$settings_2 = get_option( 'simpay_settings_keys' );
 
@@ -107,15 +110,25 @@ function simpay_lite_deprecation_notice() {
 		$key_2 = simpay_get_account_id();
 	}
 
-	// If there is no API settings in 2.x and there are in 1.x, show a message to update.
-	if ( $key_1 && ! $key_2 ) {
-		$notice_message = '<p><strong>' . __( 'An update to your settings is required!', 'stripe' ) . '</strong></p>';
-		$notice_message .= '<p>' . __( 'It looks like you may still be relying on the legacy settings of this plugin. These settings will no longer work in the next update of Stripe Payments for WordPress.', 'stripe' ) . '</p>';
-		$notice_message .= '<p>' . sprintf( __( 'Please %2$supdate your settings%1$s then %3$screate a new form%1$s to generate an updated shortcode to use on your pages.', 'stripe' ), '</a>', '<a href="' . admin_url( 'admin.php?page=simpay_settings' ) . '">', '<a href="' . admin_url( 'admin.php?page=simpay&action=create' ) . '">' ) . '</p>';
-
-		SimplePay\Core\Admin\Notices::print_notice( $notice_message );
-	}
+	return $key_1 && ! $key_2;
 }
+
+/**
+ * Show a deprecation notice about 1.x shortcode/settings.
+ */
+function simpay_lite_deprecation_notice() {
+	$notice_message = '<p><strong>' . __( 'An update to your settings is required!', 'stripe' ) . '</strong></p>';
+	$notice_message .= '<p>' . __( 'It looks like you may still be relying on the legacy settings of this plugin. These settings will no longer work in the next update of Stripe Payments for WordPress.', 'stripe' ) . '</p>';
+	$notice_message .= '<p>' . sprintf( __( 'Please %2$supdate your settings%1$s then %3$screate a new form%1$s to generate an updated shortcode to use on your pages.', 'stripe' ), '</a>', '<a href="' . admin_url( 'admin.php?page=simpay_settings' ) . '">', '<a href="' . admin_url( 'admin.php?page=simpay&action=create' ) . '">' ) . '</p>';
+
+	SimplePay\Core\Admin\Notices::print_notice( $notice_message );
+}
+
+if ( ! simpay_lite_needs_legacy() ) {
+	return;
+}
+
+// Notice about code removal.
 add_action( 'admin_notices', 'simpay_lite_deprecation_notice' );
 
 // Let's get going finally!


### PR DESCRIPTION
Closes #89 

Same logic as the notice we were going to show in 2.1.0 anyway, but this also now removes the menu item for people who do not see the notice.