### PR TITLE
Do not use floatval() to format amount on the default form.

### DIFF
--- a/includes/core/abstracts/form.php
+++ b/includes/core/abstracts/form.php
@@ -258,7 +258,7 @@ abstract class Form {
 
 		/* one-time payment options */
 
-		$this->amount = simpay_get_filtered( 'amount', simpay_get_saved_meta( $this->id, '_amount', simpay_global_minimum_amount() ), $this->id );
+		$this->amount = simpay_unformat_currency( simpay_get_filtered( 'amount', simpay_get_saved_meta( $this->id, '_amount', simpay_global_minimum_amount() ), $this->id ) );
 
 		// Statement descriptor
 		$this->statement_descriptor = simpay_get_filtered( 'statement_descriptor', null, $this->id );

--- a/includes/core/forms/default-form.php
+++ b/includes/core/forms/default-form.php
@@ -136,7 +136,7 @@ class Default_Form extends Form {
 		if ( ! empty( $this->custom_fields ) && is_array( $this->custom_fields ) ) {
 
 			foreach ( $this->custom_fields as $k => $v ) {
-	
+
 				/*
 				 * These filters are deprecated but still here for backwards compatibility
 				 */
@@ -197,7 +197,7 @@ class Default_Form extends Form {
 		}
 
 		$integers['integers'] = array(
-			'amount' => floatval( $this->amount ),
+			'amount' => $this->amount,
 		);
 
 		$strings['strings'] = array(


### PR DESCRIPTION
Closes #91 

This now matches how the Pro form sets the amount (https://github.com/wpsimplepay/WP-Simple-Pay-Pro-3/blob/release/3.4.0/includes/pro/forms/pro-form.php#L829), which is why it only happens on the Lite version's Checkout.